### PR TITLE
게임 페이지에 룰렛과 결과 모달 컴포넌트 추가

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
     "tabWidth": 2,
     "trailingComma": "all",
     "printWidth": 120,
-    "parser": "babel",
+    "parser": "babel-ts",
     "bracketSpacing": true,
     "arrowParens": "avoid"
   }

--- a/src/app/constants/foodData.ts
+++ b/src/app/constants/foodData.ts
@@ -1,4 +1,4 @@
-const mockData = [
+export const mockData = [
   { id: 'food-001', name: '김치찌개', imageURL: '', category: '한식' },
   { id: 'food-002', name: '불고기', imageURL: '', category: '한식' },
   { id: 'food-003', name: '비빔밥', imageURL: '', category: '한식' },
@@ -21,4 +21,4 @@ const mockData = [
   { id: 'food-020', name: '마라탕', imageURL: '', category: '중식' },
 ];
 
-const category = ['양식', '한식', '일식', '중식', '간편식', '디저트', '분식', '기타'];
+export const category = ['양식', '한식', '일식', '중식', '간편식', '디저트', '분식', '기타'];

--- a/src/app/game/components/Modal.tsx
+++ b/src/app/game/components/Modal.tsx
@@ -1,3 +1,0 @@
-export const Modal = () => {
-  return <div>Modal</div>;
-};

--- a/src/app/game/components/RouletteResultModal.tsx
+++ b/src/app/game/components/RouletteResultModal.tsx
@@ -1,0 +1,44 @@
+interface ModalProps {
+  result: string;
+  onClose: () => void;
+}
+
+export const RouletteResultModal: React.FC<ModalProps> = ({ result, onClose }) => {
+  if (typeof window !== 'undefined') {
+    document.body.style.overflow = 'hidden';
+  }
+
+  const handleClose = () => {
+    document.body.style.overflow = '';
+    onClose();
+  };
+
+  const handleRedirect = () => {
+    const searchUrl = `https://map.naver.com/p/search/${result}맛집`;
+    window.open(searchUrl, '_blank');
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="flex flex-col items-center justify-between w-96 min-w-80 h-5/6 bg-white rounded-2xl shadow-lg p-10 text-center">
+        <h2 className="text-2xl font-bold m-4">오늘의 메뉴</h2>
+        <div className="flex flex-col items-center justify-center">
+          <p className="text-lg m-2">{result}</p>
+          <div className="w-72 h-72 m-2 bg-gray-300 rounded-lg" />
+          <button
+            onClick={handleRedirect}
+            className="px-9 py-4 m-4 bg-[#FF4D4D] text-white rounded-lg hover:bg-red-700"
+          >
+            내 주변 {result} 맛집 바로가기
+          </button>
+        </div>
+        <button
+          onClick={handleClose}
+          className="px-4 py-2 m-2 bg-white text-[#FDB87D] text-sm border border-[#FDB87D] rounded-lg hover:bg-[#FDB87D] hover:text-white transition-colors"
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/game/components/RouletteResultModal.tsx
+++ b/src/app/game/components/RouletteResultModal.tsx
@@ -15,7 +15,8 @@ export const RouletteResultModal: React.FC<ModalProps> = ({ result, onClose }) =
 
   const handleRedirect = () => {
     const searchUrl = `https://map.naver.com/p/search/${result}맛집`;
-    window.open(searchUrl, '_blank');
+    const newWindow = window.open(searchUrl, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
   };
 
   return (

--- a/src/app/game/components/RouletteWheel.tsx
+++ b/src/app/game/components/RouletteWheel.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { mockData } from '@/app/constants/foodData';
+import { useState } from 'react';
+import { RouletteResultModal } from './RouletteResultModal';
+
+interface RouletteWheelProps {
+  spinDuration?: number;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const RouletteWheel: React.FC<RouletteWheelProps> = ({ spinDuration = 5000, size = 'lg' }) => {
+  const [isSpinning, setIsSpinning] = useState<boolean>(false);
+  const [rotation, setRotation] = useState<number>(0);
+  const [result, setResult] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const sizeClasses = {
+    sm: 'w-48 h-48',
+    md: 'w-64 h-64',
+    lg: 'w-96 h-96',
+  };
+
+  const spinWheel = async (): Promise<void> => {
+    if (isSpinning) return;
+
+    setIsSpinning(true);
+    setResult(null);
+
+    const spinDegrees = 1080 + Math.random() * 720;
+    setRotation(prev => prev + spinDegrees);
+
+    const apiResult = await fetchRandomResult();
+
+    setTimeout(() => {
+      setIsSpinning(false);
+      setResult(apiResult);
+      setIsModalOpen(true);
+    }, spinDuration);
+  };
+
+  const fetchRandomResult = async (): Promise<string> => {
+    const randomIndex = Math.floor(Math.random() * mockData.length);
+    return mockData[randomIndex].name;
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-8">
+      <div className={`relative ${sizeClasses[size]}`}>
+        {/* Pointer */}
+        <div
+          className="absolute top-0 left-1/2 -translate-x-1/2 translate-y-1 w-0 h-0 border-x-8 border-x-transparent border-t-[16px] border-t-red-700 z-10"
+          role="presentation"
+        />
+        {/* Wheel */}
+        <div
+          className="relative w-full h-full rounded-full overflow-hidden border-4 border-gray-800 bg-white"
+          style={{
+            transform: `rotate(${rotation}deg)`,
+            transition: isSpinning ? `transform ${spinDuration}ms cubic-bezier(0.17, 0.67, 0.12, 0.99)` : 'none',
+          }}
+          role="img"
+          aria-label="Decorative roulette wheel"
+        >
+          {/* Decorative sectors */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="text-2xl font-bold text-gray-500">오늘의 메뉴는...</div>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={spinWheel}
+        disabled={isSpinning}
+        className="px-6 py-2 bg-[#FF4D4D] text-white rounded-lg disabled:bg-[#FDB87D] hover:bg-red-700 transition-colors"
+        aria-busy={isSpinning}
+      >
+        {isSpinning ? '돌리는 중...' : '랜덤 돌리기'}
+      </button>
+
+      {isModalOpen && result && <RouletteResultModal result={result} onClose={() => setIsModalOpen(false)} />}
+    </div>
+  );
+};
+
+export default RouletteWheel;

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,7 +1,9 @@
+import RouletteWheel from './components/RouletteWheel';
+
 export default function Page() {
   return (
-    <div>
-      <h1>룰렛</h1>
-    </div>
+    <main className="p-8">
+      <RouletteWheel />
+    </main>
   );
 }


### PR DESCRIPTION
## 해당 PR 설명
- /game 페이지에 룰렛 애니메이션과 룰렛 돌아간 후 결과가 보여지는 모달 컴포넌트 추가
- prettier parser에 이슈가 있어서 babel-ts로 변경

## 변경 사항
- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 기능 / 레이아웃 수정
- [ ] 문서 수정
- [ ] 리팩토링

## 스크린샷 
### 룰렛 기본 이미지
<img width="658" alt="Screen Shot 2024-12-20 at 9 51 25 PM" src="https://github.com/user-attachments/assets/d9988981-08cd-4513-9cf1-50bf67118959" />

### 룰렛 추첨 결과 모달
<img width="413" alt="Screen Shot 2024-12-20 at 9 51 43 PM" src="https://github.com/user-attachments/assets/3e3f34ff-d957-42ee-835d-69be12d7963c" />

## 기타 참고사항
- 모달에서 내 주변 맛집 바로가기 버튼 클릭시 '해당 음식 이름 + 맛집'이 검색 쿼리스트링으로 포함된 네이버 지도 페이지로 이동
- 모달 내 결과 음식 이미지는 아직 보여지지 않음 (imageURL 추후 db에 추가 예정)
- 모달이 켜져있을때 background scroll lock 적용. outside click시 모달 꺼지게 하게 하는 기능도 필요할지 추후 검토.
- 룰렛 애니메이션 추후 변경 예정
