### PR TITLE
데이터 연동하여 룰렛 결과 모달에 음식 이미지 추가

### DIFF
--- a/src/app/components/Card.tsx
+++ b/src/app/components/Card.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Image from 'next/image';
 
-interface FoodData {
+export interface FoodData {
   id: number;
   name: string;
   imageURL: string;
@@ -17,7 +17,14 @@ interface CardProps {
 export default function Card({ foodData }: CardProps) {
   return (
     <div className="relative w-80 h-80 border-2 border-gray-800 rounded-lg overflow-hidden">
-      <Image src={foodData.imageURL ? foodData.imageURL : '/images/pizza.jpg'} alt="FoodImage" sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"  priority={true} fill className="object-cover" />
+      <Image
+        src={foodData.imageURL ? foodData.imageURL : '/images/pizza.jpg'}
+        alt="FoodImage"
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        priority={true}
+        fill
+        className="object-cover"
+      />
       <div className="absolute bottom-0 bg-black bg-opacity-50 text-white text-center w-full py-1">{foodData.name}</div>
     </div>
   );

--- a/src/app/game/components/RouletteResultModal.tsx
+++ b/src/app/game/components/RouletteResultModal.tsx
@@ -1,9 +1,14 @@
+import Image from 'next/image';
+import { FoodData } from '@/app/components/Card';
+
 interface ModalProps {
-  result: string;
+  result: FoodData;
   onClose: () => void;
 }
 
 export const RouletteResultModal: React.FC<ModalProps> = ({ result, onClose }) => {
+  const { name, imageURL } = result;
+
   if (typeof window !== 'undefined') {
     document.body.style.overflow = 'hidden';
   }
@@ -13,29 +18,47 @@ export const RouletteResultModal: React.FC<ModalProps> = ({ result, onClose }) =
     onClose();
   };
 
+  const handleBackgroundClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      handleClose();
+    }
+  };
+
   const handleRedirect = () => {
-    const searchUrl = `https://map.naver.com/p/search/${result}맛집`;
+    const searchUrl = `https://map.naver.com/p/search/${name}맛집`;
     const newWindow = window.open(searchUrl, '_blank', 'noopener,noreferrer');
     if (newWindow) newWindow.opener = null;
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-      <div className="flex flex-col items-center justify-between w-96 min-w-80 h-5/6 bg-white rounded-2xl shadow-lg p-10 text-center">
-        <h2 className="text-2xl font-bold m-4">오늘의 메뉴</h2>
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={handleBackgroundClick}
+    >
+      <div className="flex flex-col items-center justify-between w-96 min-w-80 h-4/5 min-h-[620px] h-m bg-white rounded-2xl shadow-lg p-10 text-center">
+        <h2 className="text-2xl font-bold m-3">오늘의 메뉴</h2>
         <div className="flex flex-col items-center justify-center">
-          <p className="text-lg m-2">{result}</p>
-          <div className="w-72 h-72 m-2 bg-gray-300 rounded-lg" />
+          <p className="text-lg m-2">{name}</p>
+          <div className="w-72 h-72 m-2 bg-gray-300 rounded-lg overflow-hidden relative">
+            <Image
+              src={imageURL}
+              alt="FoodImage"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              priority={true}
+              fill
+              className="object-cover"
+            />
+          </div>
           <button
             onClick={handleRedirect}
-            className="px-9 py-4 m-4 bg-[#FF4D4D] text-white rounded-lg hover:bg-red-700"
+            className="px-9 py-4 m-3 bg-[#FF4D4D] text-white rounded-lg hover:bg-red-700"
           >
-            내 주변 {result} 맛집 바로가기
+            내 주변 {name} 맛집 바로가기
           </button>
         </div>
         <button
           onClick={handleClose}
-          className="px-4 py-2 m-2 bg-white text-[#FDB87D] text-sm border border-[#FDB87D] rounded-lg hover:bg-[#FDB87D] hover:text-white transition-colors"
+          className="px-4 py-2 m-2 bg-white text-[#FF4D4D] text-sm border border-[#FF4D4D] rounded-lg hover:bg-[#FF4D4D] hover:text-white  transition-colors"
         >
           닫기
         </button>

--- a/src/app/game/components/RouletteWheel.tsx
+++ b/src/app/game/components/RouletteWheel.tsx
@@ -1,30 +1,30 @@
 'use client';
-import { mockData } from '@/app/constants/foodData';
 import { useState } from 'react';
 import { RouletteResultModal } from './RouletteResultModal';
+import { FoodData } from '@/app/components/Card';
 
 interface RouletteWheelProps {
   spinDuration?: number;
   size?: 'sm' | 'md' | 'lg';
 }
 
-const RouletteWheel: React.FC<RouletteWheelProps> = ({ spinDuration = 5000, size = 'lg' }) => {
+const RouletteWheel: React.FC<RouletteWheelProps> = ({ spinDuration = 2000, size = 'lg' }) => {
   const [isSpinning, setIsSpinning] = useState<boolean>(false);
   const [rotation, setRotation] = useState<number>(0);
-  const [result, setResult] = useState<string | null>(null);
+  const [result, setResult] = useState<FoodData | undefined>(undefined);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const sizeClasses = {
     sm: 'w-48 h-48',
     md: 'w-64 h-64',
-    lg: 'w-96 h-96',
+    lg: 'w-[36rem] h-[36rem]',
   };
 
   const spinWheel = async (): Promise<void> => {
     if (isSpinning) return;
 
     setIsSpinning(true);
-    setResult(null);
+    setResult(undefined);
 
     const spinDegrees = 1080 + Math.random() * 720;
     setRotation(prev => prev + spinDegrees);
@@ -38,9 +38,19 @@ const RouletteWheel: React.FC<RouletteWheelProps> = ({ spinDuration = 5000, size
     }, spinDuration);
   };
 
-  const fetchRandomResult = async (): Promise<string> => {
-    const randomIndex = Math.floor(Math.random() * mockData.length);
-    return mockData[randomIndex].name;
+  const fetchRandomResult = async (): Promise<FoodData | undefined> => {
+    try {
+      const response = await fetch('/data/list.json');
+      if (!response.ok) {
+        throw new Error('Failed to fetch data');
+      }
+      const data = await response.json();
+      const randomIndex = Math.floor(Math.random() * data.data.length);
+      return data.data[randomIndex];
+    } catch (error) {
+      console.error('Error fetching data:', error);
+      return undefined;
+    }
   };
 
   return (


### PR DESCRIPTION
## 해당 PR 설명
- mockData 대신 로컬 데이터 연결 하여 룰렛 결과 모달에서 해당 음식의 이미지가 뜨도록 변경
- 모달 오픈 되어있을 시 background 클릭 시 모달 닫힘 기능 추가

## 변경 사항
- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [x] 기능 / 레이아웃 수정
- [ ] 문서 수정
- [ ] 리팩토링

## 스크린샷 
![Uploading Screen Shot 2024-12-22 at 8.56.01 PM.png…]()


## 기타 참고사항

